### PR TITLE
refactor: use RwLock for interior mutability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown2mrkdwn"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A library which converts GitHub Flavored Markdown to Slack's mrkdwn or blocks."
 license = "MIT"

--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -1,9 +1,7 @@
-use markdown2mrkdwn::Mrkdwn;
-
 fn main() {
     println!(
         "{}",
-        Mrkdwn::from(std::fs::read_to_string("examples/sample.md").unwrap().as_str())
+        markdown2mrkdwn::Mrkdwn::from(std::fs::read_to_string("examples/sample.md").unwrap().as_str())
             .blockify()
             .unwrap()
     );

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,7 @@ use markdown2mrkdwn::Mrkdwn;
 fn main() {
     println!(
         "{}",
-        Mrkdwn::from("`mrkdwn` is text formatting markup style in [Slack](https://slack.com/).")
+        Mrkdwn::from(std::fs::read_to_string("examples/sample.md").unwrap().as_str())
             .mrkdwnify()
             .unwrap()
     );

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,9 +1,7 @@
-use markdown2mrkdwn::Mrkdwn;
-
 fn main() {
     println!(
         "{}",
-        Mrkdwn::from(std::fs::read_to_string("examples/sample.md").unwrap().as_str())
+        markdown2mrkdwn::Mrkdwn::from(std::fs::read_to_string("examples/sample.md").unwrap().as_str())
             .mrkdwnify()
             .unwrap()
     );

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,7 +1,5 @@
 use std::error::Error;
 
-use serde_json::{json, Value};
-
 #[derive(Debug)]
 pub(crate) enum Block {
     Header(String),
@@ -9,12 +7,12 @@ pub(crate) enum Block {
     Section(String),
 }
 
-impl TryFrom<Block> for Value {
+impl TryFrom<Block> for serde_json::Value {
     type Error = Box<dyn Error>;
 
     fn try_from(block: Block) -> Result<Self, Self::Error> {
         Ok(match block {
-            Block::Header(text) => json!({
+            Block::Header(text) => serde_json::json!({
                 "type": "header",
                 "text": {
                     "type": "plain_text",
@@ -22,10 +20,10 @@ impl TryFrom<Block> for Value {
                     "emoji": true,
                 },
             }),
-            Block::Divider => json!({
+            Block::Divider => serde_json::json!({
                 "type": "divider",
             }),
-            Block::Section(text) => json!({
+            Block::Section(text) => serde_json::json!({
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",


### PR DESCRIPTION
- refactor: use RwLock for interior mutability
- refactor: remove redundancy
- refactor: internal cleanup
- refactor: organize imports
