### PR TITLE
feat: percent-encode characters that break Slack link syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,11 @@ mod test {
             r#"{ "blocks": [ { "text": { "text": "<https://slack.com/|Slack>\n", "type": "mrkdwn" }, "type": "section" } ] }"#
         );
         test!(
+            link_with_pipe,
+            "[a|b](https://x.com/?q=a|b)",
+            r#"{ "blocks": [ { "text": { "text": "<https://x.com/?q=a%7Cb|ab>\n", "type": "mrkdwn" }, "type": "section" } ] }"#
+        );
+        test!(
             lists,
             "- First\n- Second\n- Third",
             r#"{ "blocks": [ { "text": { "text": "•   First\n•   Second\n•   Third\n\n", "type": "mrkdwn" }, "type": "section" } ] }"#
@@ -210,6 +215,18 @@ Another paragraph.
             "*Heading 1*\\n\\n*Heading 2*\\n\\n*Heading 3*"
         );
         test!(link, "[Slack](https://slack.com/)", "<https://slack.com/|Slack>");
+        test!(
+            link_with_pipe_in_url,
+            "[text](https://x.com/?q=a|b)",
+            "<https://x.com/?q=a%7Cb|text>"
+        );
+        test!(link_with_pipe_in_text, "[a|b](https://x.com/)", "<https://x.com/|ab>");
+        test!(
+            link_with_pipe_and_angle_brackets,
+            "[a|b>c](https://x.com/?q=a|b)",
+            "<https://x.com/?q=a%7Cb|ab&gt;c>"
+        );
+        test!(image_with_pipe, "![a|b](https://x.com/?q=a|b)", "<https://x.com/?q=a%7Cb|ab>");
         test!(lists, "- First\n- Second\n- Third", "•   First\\n•   Second\\n•   Third");
         test!(ordered_lists, "1. First\n1. Second\n1. Third", "1.  First\\n2.  Second\\n3.  Third");
         test!(

--- a/src/mrkdwn.rs
+++ b/src/mrkdwn.rs
@@ -197,6 +197,20 @@ impl<'a> Mrkdwn<'a> {
         format!("{prefix}{s}{suffix}")
     }
 
+    /// Formats a mrkdwn `<url|text>` link.
+    ///
+    /// `|`, `<`, and `>` break Slack's link parsing and have no escape sequence inside a link.
+    /// In the URL they are percent-encoded, which keeps the URL equivalent; in the text `|` is
+    /// dropped (`<`/`>` in text are already HTML-escaped by [`Self::escape`]).
+    fn mrkdwn_link(url: &str, text: &str) -> String {
+        format!("<{}|{}>", Self::sanitize_url(url), text.replace('|', ""))
+    }
+
+    /// Percent-encodes the characters that terminate or split Slack's `<url|text>` syntax.
+    fn sanitize_url(url: &str) -> String {
+        url.replace('|', "%7C").replace('<', "%3C").replace('>', "%3E")
+    }
+
     /// Escapes the three mrkdwn control characters as HTML entities, as Slack requires for
     /// literal text in `mrkdwn` text objects.
     ///
@@ -344,9 +358,9 @@ impl<'a> Mrkdwn<'a> {
     /// embedded. Falls back to a bare `<url>` link when the image has no alt text.
     fn image_to_link(image: &Image) -> String {
         if image.alt.trim().is_empty() {
-            format!("<{}>", image.url)
+            format!("<{}>", Self::sanitize_url(&image.url))
         } else {
-            format!("<{}|{}>", image.url, Self::escape(&image.alt))
+            Self::mrkdwn_link(&image.url, &Self::escape(&image.alt))
         }
     }
 


### PR DESCRIPTION
`|`, `<`, and `>` terminate or split Slack's `<url|text>` syntax and
have no escape sequence inside a link. Percent-encode them in URLs to
keep the URL equivalent, and drop `|` from link text.